### PR TITLE
Overwriting { flex: 1 } style in PopoverContainer

### DIFF
--- a/lib/PopoverContainer.js
+++ b/lib/PopoverContainer.js
@@ -15,11 +15,13 @@ class PopoverContainer extends Component {
   static propTypes = {
     children: PropTypes.node,
     padding: PropTypes.number,
+    containerStyle: PropTypes.object,
   };
 
   static defaultProps = {
     children: null,
     padding: 0,
+    containerStyle: null,
   };
 
   static childContextTypes = {
@@ -75,7 +77,7 @@ class PopoverContainer extends Component {
         ref={x => {
           this._root = x;
         }}
-        style={{ flex: 1 }}
+        style={this.props.containerStyle ? this.props.containerStyle : { flex: 1 }}
         onLayout={this.onRootLayout}
       >
         {this.props.children}

--- a/lib/PopoverContainer.js
+++ b/lib/PopoverContainer.js
@@ -21,7 +21,7 @@ class PopoverContainer extends Component {
   static defaultProps = {
     children: null,
     padding: 0,
-    containerStyle: null,
+    containerStyle: {flex: 1},
   };
 
   static childContextTypes = {
@@ -77,7 +77,7 @@ class PopoverContainer extends Component {
         ref={x => {
           this._root = x;
         }}
-        style={this.props.containerStyle ? this.props.containerStyle : { flex: 1 }}
+        style={this.props.containerStyle}
         onLayout={this.onRootLayout}
       >
         {this.props.children}


### PR DESCRIPTION
Added a new prop called containerStyle which defaults to { flex: 1 } as it was.
This enables better control over the styling of adjacent popovers without having them stretch apart due to flex.